### PR TITLE
feat: added tutorial

### DIFF
--- a/OrbitalDrift.xcodeproj/project.pbxproj
+++ b/OrbitalDrift.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		3B9D9EBB2E5A357B006281F0 /* MainMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B9D9EBA2E5A357B006281F0 /* MainMenuView.swift */; };
 		3B9D9EBD2E5A3582006281F0 /* HighScoresView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B9D9EBC2E5A3582006281F0 /* HighScoresView.swift */; };
 		3B9D9EBF2E5A3588006281F0 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B9D9EBE2E5A3588006281F0 /* SettingsView.swift */; };
+		3B9D9ED92E5AC5F2006281F0 /* TutorialView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B9D9ED82E5AC5F2006281F0 /* TutorialView.swift */; };
+		3B9D9EDB2E5ACCC5006281F0 /* DemoOrbitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B9D9EDA2E5ACCC5006281F0 /* DemoOrbitView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -52,6 +54,8 @@
 		3B9D9EBA2E5A357B006281F0 /* MainMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainMenuView.swift; sourceTree = "<group>"; };
 		3B9D9EBC2E5A3582006281F0 /* HighScoresView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighScoresView.swift; sourceTree = "<group>"; };
 		3B9D9EBE2E5A3588006281F0 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		3B9D9ED82E5AC5F2006281F0 /* TutorialView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorialView.swift; sourceTree = "<group>"; };
+		3B9D9EDA2E5ACCC5006281F0 /* DemoOrbitView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoOrbitView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -121,6 +125,8 @@
 		3B9D9EA92E5A3079006281F0 /* Soruces */ = {
 			isa = PBXGroup;
 			children = (
+				3B9D9EDA2E5ACCC5006281F0 /* DemoOrbitView.swift */,
+				3B9D9ED82E5AC5F2006281F0 /* TutorialView.swift */,
 				3B9D9EBE2E5A3588006281F0 /* SettingsView.swift */,
 				3B9D9EBC2E5A3582006281F0 /* HighScoresView.swift */,
 				3B9D9EBA2E5A357B006281F0 /* MainMenuView.swift */,
@@ -280,10 +286,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3B9D9ED92E5AC5F2006281F0 /* TutorialView.swift in Sources */,
 				3B9D9EBD2E5A3582006281F0 /* HighScoresView.swift in Sources */,
 				3B9D9EBB2E5A357B006281F0 /* MainMenuView.swift in Sources */,
 				3B9D9EB02E5A3140006281F0 /* GameState.swift in Sources */,
 				3B9D9EB12E5A3140006281F0 /* OverlayViews.swift in Sources */,
+				3B9D9EDB2E5ACCC5006281F0 /* DemoOrbitView.swift in Sources */,
 				3B9D9EB22E5A3140006281F0 /* Haptics.swift in Sources */,
 				3B9D9EB92E5A356C006281F0 /* ScoreStore.swift in Sources */,
 				3B9D9EB32E5A3140006281F0 /* OrbiterGameView.swift in Sources */,

--- a/OrbitalDrift/ContentView.swift
+++ b/OrbitalDrift/ContentView.swift
@@ -25,6 +25,10 @@ struct ContentView: View {
                         HighScoresView()
                     case .settings:
                         SettingsView()
+                    case .tutorialOnboarding:
+                        TutorialView(mode: .onboarding)
+                    case .tutorial:
+                        TutorialView(mode: .standalone)
                     }
                 }
         }

--- a/Soruces/AppRouter.swift
+++ b/Soruces/AppRouter.swift
@@ -13,6 +13,8 @@ enum AppScreen: Hashable {
     case game
     case highScores
     case settings
+    case tutorialOnboarding
+    case tutorial
 }
 
 @MainActor

--- a/Soruces/DemoOrbitView.swift
+++ b/Soruces/DemoOrbitView.swift
@@ -1,0 +1,217 @@
+//
+//  DemoOrbitView.swift
+//  OrbitalDrift
+//
+//  Created by Amish Patel on 24/08/2025.
+//
+
+
+import SwiftUI
+
+// MARK: - 1) Drag-to-Orbit demo
+struct DemoOrbitView: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        ZStack {
+            starfield
+            TimelineView(.animation) { timeline in
+                Canvas { context, size in
+                    let center = CGPoint(x: size.width/2, y: size.height/2)
+                    let radius: CGFloat = min(size.width, size.height) * 0.28
+
+                    // Orbit ring
+                    let ring = Path(ellipseIn: CGRect(x: center.x - radius, y: center.y - radius,
+                                                      width: radius*2, height: radius*2))
+                    context.stroke(ring, with: .color(.white.opacity(0.25)), lineWidth: 2)
+
+                    // Animate the ship around the ring
+                    let t = timeline.date.timeIntervalSinceReferenceDate
+                    let angle = reduceMotion ? .pi/3 : CGFloat(t).truncatingRemainder(dividingBy: .pi*2)
+                    let pos = CGPoint(x: center.x + cos(angle) * radius,
+                                      y: center.y + sin(angle) * radius)
+                    // Ship
+                    let r: CGFloat = 10
+                    context.fill(Path(ellipseIn: CGRect(x: pos.x - r, y: pos.y - r, width: r*2, height: r*2)),
+                                 with: .color(.white))
+                }
+            }
+        }
+        .frame(height: 180)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+        .overlay(RoundedRectangle(cornerRadius: 16).stroke(.white.opacity(0.12), lineWidth: 1))
+    }
+
+    private var starfield: some View {
+        LinearGradient(colors: [.black, .purple.opacity(0.45)],
+                       startPoint: .topLeading, endPoint: .bottomTrailing)
+            .overlay(
+                StarsLayer()
+                    .blendMode(.screen)
+                    .opacity(0.7)
+            )
+    }
+}
+
+// MARK: - 2) Dodge asteroids demo
+struct DemoDodgeView: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    struct Rock { var p: CGPoint; var v: CGVector; var s: CGFloat }
+    @State private var rocks: [Rock] = []
+
+    var body: some View {
+        ZStack { starBG
+            TimelineView(.animation) { timeline in
+                Canvas { context, size in
+                    var rocksLocal = rocks
+                    if rocksLocal.isEmpty { rocksLocal = seed(size: size) }
+
+                    // Player point in lower-left moving gently
+                    let t = timeline.date.timeIntervalSinceReferenceDate
+                    let px = size.width*0.25 + sin(t*1.2) * 16
+                    let py = size.height*0.70 + cos(t*0.8) * 12
+                    let player = CGPoint(x: px, y: py)
+                    context.fill(Path(ellipseIn: CGRect(x: player.x-7, y: player.y-7, width: 14, height: 14)),
+                                 with: .color(.white))
+
+                    // Update/draw rocks
+                    let dt: CGFloat = reduceMotion ? 0 : 1/60
+                    var updated: [Rock] = []
+                    for r in rocksLocal {
+                        var p = r.p
+                        p.x += r.v.dx * dt
+                        p.y += r.v.dy * dt
+
+                        // respawn if offscreen
+                        if p.x < -40 || p.x > size.width+40 || p.y < -40 || p.y > size.height+40 {
+                            // skip; new one will be added
+                        } else {
+                            updated.append(Rock(p: p, v: r.v, s: r.s))
+                            context.fill(Path(ellipseIn: CGRect(x: p.x-r.s, y: p.y-r.s, width: r.s*2, height: r.s*2)),
+                                         with: .color(.white.opacity(0.9)))
+                        }
+                    }
+                    // top up to 6
+                    while updated.count < 6 { updated.append(randomRock(size: size)) }
+                    rocks = updated
+                }
+            }
+        }
+        .frame(height: 180)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+        .overlay(RoundedRectangle(cornerRadius: 16).stroke(.white.opacity(0.12), lineWidth: 1))
+    }
+
+    private var starBG: some View {
+        LinearGradient(colors: [.black, .indigo.opacity(0.4)],
+                       startPoint: .topLeading, endPoint: .bottomTrailing)
+            .overlay(StarsLayer().opacity(0.8))
+    }
+
+    private func seed(size: CGSize) -> [Rock] { (0..<6).map { _ in randomRock(size: size) } }
+    private func randomRock(size: CGSize) -> Rock {
+        let edge = Int.random(in: 0..<4)
+        let start: CGPoint
+        switch edge {
+        case 0: start = CGPoint(x: CGFloat.random(in: 0...size.width), y: -20)
+        case 1: start = CGPoint(x: size.width + 20, y: CGFloat.random(in: 0...size.height))
+        case 2: start = CGPoint(x: CGFloat.random(in: 0...size.width), y: size.height + 20)
+        default: start = CGPoint(x: -20, y: CGFloat.random(in: 0...size.height))
+        }
+        let target = CGPoint(x: size.width*0.45, y: size.height*0.45)
+        let dir = CGVector(dx: target.x - start.x, dy: target.y - start.y)
+        let len = max(1, sqrt(dir.dx*dir.dx + dir.dy*dir.dy))
+        let speed = CGFloat.random(in: 60...120)
+        return Rock(p: start, v: CGVector(dx: dir.dx/len * speed, dy: dir.dy/len * speed),
+                    s: CGFloat.random(in: 6...12))
+    }
+}
+
+// MARK: - 3) Near-miss + shield demo
+struct DemoBonusView: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    @State private var angle: CGFloat = .pi * 0.15
+    @State private var nearMissFlash: CGFloat = 0
+
+    var body: some View {
+        ZStack { bg
+            TimelineView(.animation) { timeline in
+                Canvas { context, size in
+                    let center = CGPoint(x: size.width*0.52, y: size.height*0.55)
+                    let radius: CGFloat = min(size.width, size.height) * 0.26
+
+                    // ring
+                    let ring = Path(ellipseIn: CGRect(x: center.x-radius, y: center.y-radius,
+                                                      width: radius*2, height: radius*2))
+                    let c = Color.white.opacity(0.18 + 0.25 * nearMissFlash)
+                    context.stroke(ring, with: .color(c), lineWidth: 2 + 1 * nearMissFlash)
+
+                    // player & shield halo
+                    let p = CGPoint(x: center.x + cos(angle)*radius, y: center.y + sin(angle)*radius)
+                    context.fill(Path(ellipseIn: CGRect(x: p.x-7, y: p.y-7, width: 14, height: 14)),
+                                 with: .color(.white))
+                    let haloRect = CGRect(x: p.x-13, y: p.y-13, width: 26, height: 26)
+                    context.stroke(Path(ellipseIn: haloRect), with: .color(.white.opacity(0.6)), lineWidth: 2)
+
+                    // "asteroid" passes close once per cycle
+                    let t = timeline.date.timeIntervalSinceReferenceDate
+                    let a = CGFloat((t*1.2).truncatingRemainder(dividingBy: .pi*2))
+                    let aPos = CGPoint(x: center.x + cos(a) * (radius + 26),
+                                       y: center.y + sin(a) * (radius + 26))
+                    context.fill(Path(ellipseIn: CGRect(x: aPos.x-6, y: aPos.y-6, width: 12, height: 12)),
+                                 with: .color(.white.opacity(0.9)))
+
+                    // update local angle slowly
+                    if !reduceMotion { angle += 0.02 }
+
+                    // trigger flash when near
+                    let dist = hypot(aPos.x - p.x, aPos.y - p.y)
+                    if dist < 34 { nearMissFlash = 1 }
+                    nearMissFlash = max(0, nearMissFlash - 0.06)
+                }
+            }
+        }
+        .frame(height: 180)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+        .overlay(RoundedRectangle(cornerRadius: 16).stroke(.white.opacity(0.12), lineWidth: 1))
+    }
+
+    private var bg: some View {
+        LinearGradient(colors: [.black, .orange.opacity(0.35)],
+                       startPoint: .topLeading, endPoint: .bottomTrailing)
+            .overlay(StarsLayer().opacity(0.75))
+    }
+}
+
+// MARK: - Shared stars (cheap procedural layer)
+fileprivate struct StarsLayer: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    var body: some View {
+        TimelineView(.animation) { timeline in
+            Canvas { context, size in
+                let seed = UInt64(abs(Int64(timeline.date.timeIntervalSinceReferenceDate * (reduceMotion ? 0 : 0.15))))
+                var rng = SeededRandom(seed: seed)
+                for _ in 0..<160 {
+                    let x = CGFloat(rng.next()) * size.width
+                    let y = CGFloat(rng.next()) * size.height
+                    let r = CGFloat(rng.next()) * 1.2 + 0.2
+                    let alpha = 0.6 + Double(rng.next()) * 0.4
+                    context.fill(Path(ellipseIn: CGRect(x: x, y: y, width: r, height: r)),
+                                 with: .color(.white.opacity(alpha)))
+                }
+            }
+        }
+        .allowsHitTesting(false)
+    }
+}
+
+fileprivate struct SeededRandom {
+    var state: UInt64
+    init(seed: UInt64) { state = seed &* 6364136223846793005 &+ 1 }
+    mutating func next() -> CGFloat {
+        state = state &* 2862933555777941757 &+ 3037000493
+        return CGFloat((state >> 33) & 0xFFFFFF) / CGFloat(0xFFFFFF)
+    }
+}

--- a/Soruces/MainMenuView.swift
+++ b/Soruces/MainMenuView.swift
@@ -11,11 +11,10 @@ import SwiftUI
 struct MainMenuView: View {
     @EnvironmentObject var router: AppRouter
     @EnvironmentObject var scores: ScoresStore
-    @AppStorage("theme") var theme: Theme = .classic
+    @AppStorage("seenTutorial") private var seenTutorial = false
 
     var body: some View {
         ZStack {
-            // Reuse theme background if you’ve expanded Theme; fallback to gradient
             LinearGradient(stops: [
                 .init(color: Color.black.opacity(0.95), location: 0),
                 .init(color: Color.purple.opacity(0.2), location: 1)
@@ -25,39 +24,30 @@ struct MainMenuView: View {
             VStack(spacing: 24) {
                 Text("Orbital Drift")
                     .font(.system(size: 44, weight: .black, design: .rounded))
-
                 Text("Best: \(scores.best)")
                     .font(.headline).monospacedDigit()
                     .foregroundStyle(.secondary)
 
                 VStack(spacing: 12) {
                     Button {
-                        router.go(.game)
+                        if seenTutorial {
+                            router.go(.game)
+                        } else {
+                            router.go(.tutorialOnboarding)
+                        }
                     } label: {
-                        Text("Start")
-                            .font(.title2.bold())
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, 12)
+                        Text("Start").font(.title2.bold())
+                            .frame(maxWidth: .infinity).padding(.vertical, 12)
                     }
                     .buttonStyle(.borderedProminent)
 
-                    Button {
-                        router.go(.highScores)
-                    } label: {
-                        Text("High Scores")
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, 10)
-                    }
-                    .buttonStyle(.bordered)
+                    Button { router.go(.highScores) } label: {
+                        Text("High Scores").frame(maxWidth: .infinity).padding(.vertical, 10)
+                    }.buttonStyle(.bordered)
 
-                    Button {
-                        router.go(.settings)
-                    } label: {
-                        Text("Settings")
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, 10)
-                    }
-                    .buttonStyle(.bordered)
+                    Button { router.go(.settings) } label: {
+                        Text("Settings").frame(maxWidth: .infinity).padding(.vertical, 10)
+                    }.buttonStyle(.bordered)
                 }
                 .padding(.horizontal, 24)
             }

--- a/Soruces/SettingsView.swift
+++ b/Soruces/SettingsView.swift
@@ -5,29 +5,50 @@
 //  Created by Amish Patel on 24/08/2025.
 //
 
-
 import SwiftUI
 
 struct SettingsView: View {
+    @EnvironmentObject private var router: AppRouter
     @AppStorage("theme") var theme: Theme = .classic
     @AppStorage("soundEnabled") var soundEnabled: Bool = true
     @AppStorage("hapticsEnabled") var hapticsEnabled: Bool = true
+    @AppStorage("seenTutorial") private var seenTutorial = false
+    @State private var confirmReset = false
 
     var body: some View {
         Form {
             Section("Appearance") {
                 Picker("Theme", selection: $theme) {
-                    ForEach(Theme.allCases) { Text($0.rawValue.capitalized).tag($0) }
+                    ForEach(Theme.allCases) { Text($0.rawImageName.capitalized).tag($0) } // or .rawValue if you kept that
                 }
             }
             Section("Feedback") {
                 Toggle("Sound", isOn: $soundEnabled)
                 Toggle("Haptics", isOn: $hapticsEnabled)
             }
+            Section("Tutorial") {
+                Button("View Tutorial") { router.go(.tutorial) }
+                Button("Show on Next Launch") {
+                    confirmReset = true
+                }
+                .foregroundStyle(.orange)
+            }
             Section("About") {
-                LabeledContent("Version", value: Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "–")
+                LabeledContent("Version",
+                               value: Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "–")
             }
         }
         .navigationTitle("Settings")
+        .confirmationDialog("Show tutorial on next launch?",
+                            isPresented: $confirmReset,
+                            actions: {
+                                Button("Yes", role: .none) { seenTutorial = false }
+                                Button("Cancel", role: .cancel) { }
+                            })
     }
+}
+
+private extension Theme {
+    // helper if you don’t have display names
+    var rawImageName: String { rawValue }
 }

--- a/Soruces/TutorialView.swift
+++ b/Soruces/TutorialView.swift
@@ -1,0 +1,95 @@
+//
+//  TutorialView.swift
+//  OrbitalDrift
+//
+//  Created by Amish Patel on 24/08/2025.
+//
+
+
+import SwiftUI
+
+enum TutorialMode { case onboarding, standalone }
+
+struct TutorialView: View {
+    let mode: TutorialMode
+    @AppStorage("seenTutorial") private var seenTutorial: Bool = false
+    @EnvironmentObject private var router: AppRouter
+
+    @State private var page = 0
+
+    var body: some View {
+        ZStack {
+            LinearGradient(colors: [.black, .purple.opacity(0.4)],
+                           startPoint: .top, endPoint: .bottom)
+            .ignoresSafeArea()
+
+            TabView(selection: $page) {
+                TutorialPage(
+                    title: "Drag to Orbit",
+                    message: "Touch and drag anywhere to move your ship around the planet.",
+                    demo: AnyView(DemoOrbitView())
+                ).tag(0)
+
+                TutorialPage(
+                    title: "Avoid Asteroids",
+                    message: "Dodge incoming asteroids. One hit ends the round (unless you have a shield).",
+                    demo: AnyView(DemoDodgeView())
+                ).tag(1)
+
+                TutorialPage(
+                    title: "Near Miss = Bonus",
+                    message: "Skim past for bonus points. Collect shields for a second chance.",
+                    demo: AnyView(DemoBonusView())
+                ).tag(2)
+            }
+            .tabViewStyle(.page(indexDisplayMode: .always))
+
+            // Bottom CTA
+            VStack {
+                Spacer()
+                if page == 2 {
+                    Button(action: primaryAction) {
+                        Text(mode == .onboarding ? "Let’s Play" : "Done")
+                            .font(.title3.bold())
+                            .padding(.horizontal, 32).padding(.vertical, 12)
+                            .background(.ultraThinMaterial, in: Capsule())
+                    }
+                    .padding(.bottom, 40)
+                }
+            }
+        }
+        .foregroundStyle(.white)
+    }
+
+    private func primaryAction() {
+        switch mode {
+        case .onboarding:
+            seenTutorial = true
+            router.go(.game)
+        case .standalone:
+            router.backToRoot()
+        }
+    }
+}
+
+private struct TutorialPage: View {
+    let title: String
+    let message: String
+    let demo: AnyView
+
+    var body: some View {
+        VStack(spacing: 18) {
+            Spacer(minLength: 8)
+            demo
+            Text(title).font(.title.bold())
+            Text(message)
+                .font(.body)
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 30)
+            Spacer()
+        }
+        .foregroundColor(.white)
+        .accessibilityElement(children: .combine)
+    }
+}


### PR DESCRIPTION
This pull request introduces a tutorial/onboarding flow to the Orbital Drift app, including a new multi-page tutorial with interactive demos, updates to the main menu and settings to support tutorial access, and related project configuration changes. The most important changes are grouped below:

**Tutorial Feature Implementation:**

* Added new `TutorialView.swift` implementing a three-page tutorial with interactive orbit, dodge, and bonus demos, supporting both onboarding and standalone modes. The tutorial tracks completion using the `seenTutorial` app storage key.
* Added supporting demo views for tutorial pages in `DemoOrbitView.swift`, including orbit, asteroid dodge, and near-miss/shield scenarios, with shared visual effects.

**Navigation and App State Integration:**

* Extended `AppScreen` enum in `AppRouter.swift` with `.tutorialOnboarding` and `.tutorial` cases to distinguish between onboarding and manual tutorial access.
* Updated `ContentView.swift` to route to `TutorialView` for both onboarding and standalone tutorial flows.

**Main Menu and Settings Enhancements:**

* Modified `MainMenuView.swift` to launch the tutorial on first run (when `seenTutorial` is false) instead of starting the game directly, and streamlined button code. [[1]](diffhunk://#diff-4044724e5dda85076ea16fa737243e5c6079f9f15219522468656f391f8ae589L14-L18) [[2]](diffhunk://#diff-4044724e5dda85076ea16fa737243e5c6079f9f15219522468656f391f8ae589L28-R50)
* Updated `SettingsView.swift` to allow users to view the tutorial at any time or reset the onboarding flag, with a confirmation dialog.

**Project Configuration:**

* Registered new source files (`TutorialView.swift`, `DemoOrbitView.swift`) in the Xcode project and build phases. [[1]](diffhunk://#diff-d1954a38114e5dec0354d3f1b4d2c1322dd06b31c51708a97b4909afb7aa22f6R21-R22) [[2]](diffhunk://#diff-d1954a38114e5dec0354d3f1b4d2c1322dd06b31c51708a97b4909afb7aa22f6R57-R58) [[3]](diffhunk://#diff-d1954a38114e5dec0354d3f1b4d2c1322dd06b31c51708a97b4909afb7aa22f6R128-R129) [[4]](diffhunk://#diff-d1954a38114e5dec0354d3f1b4d2c1322dd06b31c51708a97b4909afb7aa22f6R289-R294)