### PR TITLE
feat: updating scoring logic

### DIFF
--- a/Soruces/OrbiterGameView.swift
+++ b/Soruces/OrbiterGameView.swift
@@ -183,6 +183,14 @@ struct OrbiterGameView: View {
                 Text("Score \(game.score)")
                     .font(.system(.headline, design: .rounded))
                     .monospacedDigit()
+                
+                if game.scoreMultiplier > 1.0 {
+                    Text(String(format: "x%.2f", game.scoreMultiplier))
+                        .font(.headline.monospacedDigit())
+                        .padding(.horizontal, 10).padding(.vertical, 6)
+                        .background(.ultraThinMaterial, in: Capsule())
+                        .accessibilityLabel(Text("Multiplier \(String(format: "%.2f", game.scoreMultiplier))"))
+                }
 
                 if game.shieldCharges > 0 {
                     HStack(spacing: 6) {
@@ -212,8 +220,15 @@ struct OrbiterGameView: View {
                 BigButton(title: "Start") { game.reset(in: size) }
             case .paused:
                 PauseCard(
-                    resume: { game.togglePause() },
-                    restart: { game.reset(in: size) }
+                    resume: {
+                        game.togglePause()
+                    },
+                    restart: {
+                        game.reset(in: size)
+                    },
+                    mainMenu: {
+                        router.backToRoot()
+                    }
                 )
             case .gameOver:
                 GameOverCard(

--- a/Soruces/OverlayViews.swift
+++ b/Soruces/OverlayViews.swift
@@ -25,12 +25,14 @@ struct BigButton: View {
 struct PauseCard: View {
     let resume: () -> Void
     let restart: () -> Void
+    let mainMenu: () -> Void
     var body: some View {
         VStack(spacing: 12) {
             Text("Paused").font(.title2.bold())
             HStack {
                 Button("Resume", action: resume).buttonStyle(.borderedProminent)
                 Button("Restart", action: restart).buttonStyle(.bordered)
+                Button("Main Menu", action: mainMenu).buttonStyle(.bordered)
             }
         }
         .padding()


### PR DESCRIPTION
This pull request introduces a new score multiplier system to reward near-misses and high-skill play, replacing the previous flat scoring for near-misses and periodic score ticks. It also updates the pause menu to include a "Main Menu" button and improves the game UI to display the active multiplier when above 1x.

**Gameplay and Scoring Improvements:**

* Added a score multiplier mechanic to `GameState`: near-misses increase the multiplier (up to 3x), which then decays over time; destroying asteroids now grants points scaled by the multiplier instead of a flat value. [[1]](diffhunk://#diff-eee7c86a3390199db9f4b1a683de48b47cdd739b3453ef450d7e0013e2159f38R27-R33) [[2]](diffhunk://#diff-eee7c86a3390199db9f4b1a683de48b47cdd739b3453ef450d7e0013e2159f38R125-R129) [[3]](diffhunk://#diff-eee7c86a3390199db9f4b1a683de48b47cdd739b3453ef450d7e0013e2159f38L244-R258) [[4]](diffhunk://#diff-eee7c86a3390199db9f4b1a683de48b47cdd739b3453ef450d7e0013e2159f38R279-R282)
* Removed the old periodic score tick system, so points are now only awarded for skillful actions.

**User Interface Updates:**

* The active score multiplier is now displayed in the HUD when above 1x, making it clear to the player when they're earning bonus points.

**Pause Menu Enhancement:**

* Added a "Main Menu" button to the pause overlay, allowing players to return to the main menu from the pause screen. [[1]](diffhunk://#diff-ca354abee088ddd8a74c95b81d221fdd4880c84992693d40ba185029c634dd1bL215-R231) [[2]](diffhunk://#diff-66fba75aca8d7feadc88b03f1bf6a78b779f96dd4b62b5ceb2dd6d799ec42302R28-R35)