### PR TITLE
feat: added new enemy variants

### DIFF
--- a/Soruces/GameModels.swift
+++ b/Soruces/GameModels.swift
@@ -27,12 +27,42 @@ struct Bullet: Identifiable {
     var size: CGFloat = 3.5
 }
 
+enum EnemyType: Int {
+    case small
+    case big
+    case evader
+    
+    var color: Color {
+        switch self {
+        case .small:
+            return .blue
+        case .big:
+            return .red
+        case .evader:
+            return .purple
+        }
+    }
+    
+    var scoreValue: Int {
+        switch self {
+        case .small:
+            15
+        case .big:
+            40
+        case .evader:
+            30
+        }
+    }
+}
+
 struct Asteroid: Identifiable {
     let id = UUID()
     var pos: Vector2
     var vel: Vector2
     var size: CGFloat
     var alive: Bool = true
+    var type: EnemyType = .small
+    var hp: Int = 1
 }
 
 struct Particle: Identifiable {
@@ -40,6 +70,7 @@ struct Particle: Identifiable {
     var pos: Vector2
     var vel: Vector2
     var life: CGFloat // 0...1
+    var color: Color = .white
 }
 
 struct Powerup: Identifiable {

--- a/Soruces/OrbiterGameView.swift
+++ b/Soruces/OrbiterGameView.swift
@@ -82,7 +82,7 @@ struct OrbiterGameView: View {
                                 let rect = CGRect(x: a.pos.x - a.size, y: a.pos.y - a.size,
                                                   width: a.size*2, height: a.size*2)
                                 context.fill(Path(ellipseIn: rect),
-                                             with: .color(.white.opacity(0.85)))
+                                             with: .color(a.type.color))
                             }
 
                             // Powerups
@@ -98,7 +98,7 @@ struct OrbiterGameView: View {
                                 let alpha = max(0, Double(p.life))
                                 let r: CGFloat = 2 + (1 - p.life) * 2
                                 let rect = CGRect(x: p.pos.x - r, y: p.pos.y - r, width: r*2, height: r*2)
-                                context.fill(Path(ellipseIn: rect), with: .color(.white.opacity(alpha)))
+                                context.fill(Path(ellipseIn: rect), with: .color(p.color.opacity(alpha)))
                             }
 
                             // Bullets


### PR DESCRIPTION
This pull request introduces new enemy types for asteroids, each with unique behaviors, stats, and visual effects. The changes add an `EnemyType` enum to distinguish between small, big, and evader asteroids, update how asteroids are spawned and rendered, and implement type-specific scoring, movement, and particle effects.

**Asteroid Types and Behaviors:**

- Added `EnemyType` enum with `.small`, `.big`, and `.evader` variants, each with distinct color and score values. Asteroids now have a `type` and `hp` property. (`Soruces/GameModels.swift` [Soruces/GameModels.swiftR30-R73](diffhunk://#diff-2c55c70221130a47c38222f5f494841cb2c6c179e5479ac5e54aad65d9ec7f6bR30-R73))
- During asteroid spawning, the type is selected with weighted randomness, and each type gets specific speed, size, and HP. (`Soruces/GameState.swift` [[1]](diffhunk://#diff-eee7c86a3390199db9f4b1a683de48b47cdd739b3453ef450d7e0013e2159f38R368) [[2]](diffhunk://#diff-eee7c86a3390199db9f4b1a683de48b47cdd739b3453ef450d7e0013e2159f38L360-R433)
- "Evader" asteroids move away from the player each frame, introducing a new movement pattern. (`Soruces/GameState.swift` [Soruces/GameState.swiftR269-R276](diffhunk://#diff-eee7c86a3390199db9f4b1a683de48b47cdd739b3453ef450d7e0013e2159f38R269-R276))

**Scoring and Combat:**

- Asteroid HP is now decremented on bullet hits; asteroids are only destroyed when HP reaches zero. Scoring is based on asteroid type and only awarded on destruction. Non-lethal hits play a different sound. (`Soruces/GameState.swift` [Soruces/GameState.swiftL278-R302](diffhunk://#diff-eee7c86a3390199db9f4b1a683de48b47cdd739b3453ef450d7e0013e2159f38L278-R302))
- Removed the global `pointsPerKill` variable in favor of per-type scoring. (`Soruces/GameState.swift` [Soruces/GameState.swiftL27](diffhunk://#diff-eee7c86a3390199db9f4b1a683de48b47cdd739b3453ef450d7e0013e2159f38L27))

**Visual and Particle Effects:**

- Asteroid color in the game view now reflects its type. (`Soruces/OrbiterGameView.swift` [Soruces/OrbiterGameView.swiftL85-R85](diffhunk://#diff-ca354abee088ddd8a74c95b81d221fdd4880c84992693d40ba185029c634dd1bL85-R85))
- Particle bursts on asteroid hits use the asteroid's color, and `Particle` now stores its color. (`Soruces/GameModels.swift` [[1]](diffhunk://#diff-2c55c70221130a47c38222f5f494841cb2c6c179e5479ac5e54aad65d9ec7f6bR30-R73) `Soruces/GameState.swift` [[2]](diffhunk://#diff-eee7c86a3390199db9f4b1a683de48b47cdd739b3453ef450d7e0013e2159f38L360-R433)
- Particle rendering uses each particle's color and alpha. (`Soruces/OrbiterGameView.swift` [Soruces/OrbiterGameView.swiftL101-R101](diffhunk://#diff-ca354abee088ddd8a74c95b81d221fdd4880c84992693d40ba185029c634dd1bL101-R101))