### PR TITLE
feat: updated UI

### DIFF
--- a/Soruces/GameModels.swift
+++ b/Soruces/GameModels.swift
@@ -73,6 +73,15 @@ struct Particle: Identifiable {
     var color: Color = .white
 }
 
+struct KillToast: Identifiable {
+    let id = UUID()
+    var pos: Vector2           // spawn position (world coords)
+    var value: Int             // points to show
+    var color: Color           // matches enemy color
+    var age: CGFloat = 0       // seconds since spawn
+    var lifetime: CGFloat = 0.6
+}
+
 struct Powerup: Identifiable {
     let id = UUID()
     var pos: Vector2

--- a/Soruces/OrbiterGameView.swift
+++ b/Soruces/OrbiterGameView.swift
@@ -7,175 +7,77 @@
 import SwiftUI
 import UIKit
 
+// MARK: - Main Game View
+
 struct OrbiterGameView: View {
     @State private var game = GameState()
     @EnvironmentObject private var scores: ScoresStore
     @EnvironmentObject private var router: AppRouter
     @Environment(\.scenePhase) private var scenePhase
-    @AppStorage("theme") private var theme: Theme = .classic
 
     @State private var size: CGSize = .zero
-    @State private var loopTask: Task<Void, Never>?   // async display-link loop
+    @State private var loopTask: Task<Void, Never>? = nil
 
     var body: some View {
         ZStack {
             GeometryReader { proxy in
                 let proxySize = proxy.size
 
-                Color.clear
-                    .onAppear {
-                        size = proxySize
-                        game.worldCenter = CGPoint(x: proxySize.width/2, y: proxySize.height/2)
-                        game.reset(in: proxySize)
-                        startLoop(size: proxySize)
-                    }
-                    .onDisappear { stopLoop() }
-                    .onChange(of: proxy.size) {
-                        size = proxy.size
-                        game.worldCenter = CGPoint(x: proxy.size.width/2, y: proxy.size.height/2)
-                    }
-
                 ZStack {
-                    // === Playfield rendering (no state mutations here) ===
-                    TimelineView(.animation) { _ in
-                        Canvas(rendersAsynchronously: true) { context, _ in
-                            // Orbit ring (with near-miss flash)
-                            let ringPath = Path { p in
-                                p.addEllipse(in: CGRect(
-                                    x: game.worldCenter.x - game.player.radius,
-                                    y: game.worldCenter.y - game.player.radius,
-                                    width: game.player.radius * 2,
-                                    height: game.player.radius * 2
-                                ))
-                            }
-                            let flash = game.nearMissFlash
-                            let ringColor = Color.white.opacity(0.15 + 0.25 * flash)
-                            context.stroke(ringPath, with: .color(ringColor), lineWidth: 2 + 1 * flash)
-
-                            // Player
-                            let playerPos = game.playerPosition()
-                            let playerRect = CGRect(
-                                x: playerPos.x - game.player.size,
-                                y: playerPos.y - game.player.size,
-                                width: game.player.size * 2,
-                                height: game.player.size * 2
-                            )
-                            context.fill(Path(ellipseIn: playerRect), with: .color(.white))
-
-                            // Shield halo (steady when charges > 0, pulsing during i-frames)
-                            if game.shieldCharges > 0 || game.invulnerability > 0 {
-                                let pulse = game.invulnerabilityPulse
-                                let haloSize = game.player.size + 6 + CGFloat(pulse * 6)
-                                let halo = CGRect(
-                                    x: playerPos.x - haloSize,
-                                    y: playerPos.y - haloSize,
-                                    width: haloSize * 2, height: haloSize * 2
-                                )
-                                let opacity = game.invulnerability > 0 ? (0.8 - pulse * 0.3) : 0.6
-                                context.stroke(Path(ellipseIn: halo),
-                                               with: .color(.white.opacity(opacity)),
-                                               lineWidth: 2 + CGFloat(pulse))
-                            }
-
-                            // Asteroids
-                            for a in game.asteroids {
-                                let rect = CGRect(x: a.pos.x - a.size, y: a.pos.y - a.size,
-                                                  width: a.size*2, height: a.size*2)
-                                context.fill(Path(ellipseIn: rect),
-                                             with: .color(a.type.color))
-                            }
-
-                            // Powerups
-                            for p in game.powerups {
-                                let rect = CGRect(x: p.pos.x - p.size, y: p.pos.y - p.size,
-                                                  width: p.size*2, height: p.size*2)
-                                context.stroke(Path(ellipseIn: rect),
-                                               with: .color(.white.opacity(0.9)), lineWidth: 2)
-                            }
-
-                            // Particles
-                            for p in game.particles {
-                                let alpha = max(0, Double(p.life))
-                                let r: CGFloat = 2 + (1 - p.life) * 2
-                                let rect = CGRect(x: p.pos.x - r, y: p.pos.y - r, width: r*2, height: r*2)
-                                context.fill(Path(ellipseIn: rect), with: .color(p.color.opacity(alpha)))
-                            }
-
-                            // Bullets
-                            for b in game.bullets {
-                                let r = b.size
-                                let rect = CGRect(
-                                    x: CGFloat(b.pos.x) - r,
-                                    y: CGFloat(b.pos.y) - r,
-                                    width: r * 2, height: r * 2
-                                )
-                                context.fill(Path(ellipseIn: rect), with: .color(.white))
-                            }
-                            
-                            // Shockwaves (expanding rings at hit location)
-                            for w in game.shockwaves {
-                                let center = CGPoint(x: CGFloat(w.pos.x), y: CGFloat(w.pos.y))
-                                let r = CGFloat(w.age) * w.maxRadius
-                                let alpha = Double(max(0, 1 - w.age))
-                                let rect = CGRect(x: center.x - r, y: center.y - r, width: r*2, height: r*2)
-                                context.stroke(Path(ellipseIn: rect),
-                                               with: .color(.white.opacity(alpha * 0.8)),
-                                               lineWidth: max(1, 3 - r * 0.02))
-                            }
-                        }
-                    }
-                    .screenShake(game.shake)
-
-                    // === Stable input layer (does NOT move/shake) ===
-                    Color.clear
-                        .contentShape(Rectangle())
-                        .gesture(
-                            DragGesture(minimumDistance: 0)
-                                .onChanged { game.inputDrag($0) }
-                                .onEnded   { _ in game.endDrag() }
-                        )
+                    // Split the big Canvas into smaller composable canvases
+                    PlayfieldCanvas(game: game)
+                    EnemiesCanvas(game: game)
+                    BulletsCanvas(game: game)
+                    FXCanvas(game: game)
+                }
+                .screenShake(game.shake)
+                .contentShape(Rectangle()) // for gestures
+                .gesture(
+                    DragGesture(minimumDistance: 0)
+                        .onChanged { game.inputDrag($0) }
+                        .onEnded { _ in game.endDrag() }
+                )
+                .onAppear {
+                    size = proxySize
+                    game.worldCenter = CGPoint(x: proxySize.width / 2, y: proxySize.height / 2)
+                    game.reset(in: proxySize)
+                    startLoop(size: proxySize)
+                }
+                .onChange(of: proxy.size) {
+                    size = proxy.size
+                    game.worldCenter = CGPoint(x: proxy.size.width / 2, y: proxy.size.height / 2)
+                }
+                .onDisappear {
+                    stopLoop()
                 }
             }
 
-            // === HUD & overlays ===
             overlayUI
         }
-        // Music & score save on phase changes
         .onChange(of: game.phase) {
             switch game.phase {
-            case .playing:
-                MusicLoop.shared.setScene(.game)
-            case .gameOver:
-                scores.add(score: game.score)
-                MusicLoop.shared.setScene(.gameOver)
-            case .paused:
-                MusicLoop.shared.setScene(.menu)
-            case .menu:
-                MusicLoop.shared.setScene(.menu)
+            case .playing:  MusicLoop.shared.setScene(.game)
+            case .gameOver: scores.add(score: game.score); MusicLoop.shared.setScene(.gameOver)
+            case .paused:   MusicLoop.shared.setScene(.menu)
+            case .menu:     MusicLoop.shared.setScene(.menu)
             }
         }
-        // App lifecycle without Combine: pause loop when inactive, resume when active
         .onChange(of: scenePhase) {
             switch scenePhase {
             case .active:
-                // resume loop if needed
-                if loopTask == nil {
-                    startLoop(size: size)
-                }
+                if loopTask == nil { startLoop(size: size) }
             case .inactive, .background:
                 stopLoop()
-                if game.phase == .playing {
-                    game.togglePause()
-                }
-            @unknown default:
-                break
+                if game.phase == .playing { game.togglePause() }
+            @unknown default: break
             }
         }
         .preferredColorScheme(.dark)
         .accessibilityElement(children: .contain)
     }
 
-    // MARK: - Overlay
+    // MARK: - Overlay (your existing code)
+
     @ViewBuilder
     private var overlayUI: some View {
         VStack(spacing: 12) {
@@ -183,7 +85,7 @@ struct OrbiterGameView: View {
                 Text("Score \(game.score)")
                     .font(.system(.headline, design: .rounded))
                     .monospacedDigit()
-                
+
                 if game.scoreMultiplier > 1.0 {
                     Text(String(format: "x%.2f", game.scoreMultiplier))
                         .font(.headline.monospacedDigit())
@@ -220,15 +122,9 @@ struct OrbiterGameView: View {
                 BigButton(title: "Start") { game.reset(in: size) }
             case .paused:
                 PauseCard(
-                    resume: {
-                        game.togglePause()
-                    },
-                    restart: {
-                        game.reset(in: size)
-                    },
-                    mainMenu: {
-                        router.backToRoot()
-                    }
+                    resume: { game.togglePause() },
+                    restart: { game.reset(in: size) },
+                    mainMenu: { router.backToRoot()}
                 )
             case .gameOver:
                 GameOverCard(
@@ -246,6 +142,7 @@ struct OrbiterGameView: View {
     }
 
     // MARK: - Loop control
+
     private func startLoop(size: CGSize) {
         loopTask?.cancel()
         loopTask = Task { @MainActor in
@@ -258,5 +155,144 @@ struct OrbiterGameView: View {
     private func stopLoop() {
         loopTask?.cancel()
         loopTask = nil
+    }
+}
+
+// MARK: - Small Canvas Views (split to keep the compiler happy)
+
+private struct PlayfieldCanvas: View {
+    let game: GameState
+    var body: some View {
+        Canvas { context, _ in
+            // Orbit ring
+            let ringRect = CGRect(
+                x: game.worldCenter.x - game.player.radius,
+                y: game.worldCenter.y - game.player.radius,
+                width: game.player.radius * 2,
+                height: game.player.radius * 2
+            )
+            let ringPath = Path(ellipseIn: ringRect)
+            let flash = game.nearMissFlash
+            let ringColor = Color.white.opacity(0.15 + 0.25 * flash)
+            context.stroke(ringPath, with: .color(ringColor), lineWidth: 2 + 1 * flash)
+
+            // Player
+            let playerPos = game.playerPosition()
+            let pr = game.player.size
+            let playerRect = CGRect(x: playerPos.x - pr, y: playerPos.y - pr, width: pr * 2, height: pr * 2)
+            context.fill(Path(ellipseIn: playerRect), with: .color(.white))
+
+            // Shield halo
+            if game.shieldCharges > 0 || game.invulnerability > 0 {
+                let pulse = game.invulnerabilityPulse
+                let haloSize = pr + 6 + CGFloat(pulse * 6)
+                let haloRect = CGRect(x: playerPos.x - haloSize, y: playerPos.y - haloSize, width: haloSize * 2, height: haloSize * 2)
+                let opacity = game.invulnerability > 0 ? (0.8 - pulse * 0.3) : 0.6
+                context.stroke(Path(ellipseIn: haloRect),
+                               with: .color(.white.opacity(opacity)),
+                               lineWidth: 2 + CGFloat(pulse))
+            }
+        }
+        .allowsHitTesting(false)
+    }
+}
+
+private struct EnemiesCanvas: View {
+    let game: GameState
+    var body: some View {
+        Canvas { context, _ in
+            // Asteroids / Enemies
+            for a in game.asteroids where a.alive {
+                let rect = CGRect(x: a.pos.x - a.size, y: a.pos.y - a.size, width: a.size * 2, height: a.size * 2)
+                context.fill(Path(ellipseIn: rect), with: .color(a.type.color))
+            }
+            // Powerups
+            for p in game.powerups {
+                let rect = CGRect(x: p.pos.x - p.size, y: p.pos.y - p.size, width: p.size * 2, height: p.size * 2)
+                context.stroke(Path(ellipseIn: rect), with: .color(.white.opacity(0.9)), lineWidth: 2)
+            }
+        }
+        .allowsHitTesting(false)
+    }
+}
+
+private struct BulletsCanvas: View {
+    let game: GameState
+    var body: some View {
+        Canvas { context, _ in
+            for b in game.bullets {
+                // velocity-aligned streak
+                let v = b.vel.normalized()
+                let lead: CGFloat = 6
+                let trail: CGFloat = 10
+                let center = CGPoint(x: CGFloat(b.pos.x), y: CGFloat(b.pos.y))
+                let p1 = CGPoint(x: center.x - v.x * trail, y: center.y - v.y * trail)
+                let p2 = CGPoint(x: center.x + v.x * lead,  y: center.y + v.y * lead)
+                var path = Path()
+                path.move(to: p1)
+                path.addLine(to: p2)
+                context.stroke(path, with: .color(.white.opacity(0.95)), lineWidth: 2)
+            }
+        }
+        .allowsHitTesting(false)
+    }
+}
+
+private struct FXCanvas: View {
+    let game: GameState
+    var body: some View {
+        Canvas { context, _ in
+            // Particles
+            for p in game.particles {
+                let alpha = max(0, Double(p.life))
+                let r: CGFloat = 2 + (1 - p.life) * 2
+                let rect = CGRect(x: p.pos.x - r, y: p.pos.y - r, width: r * 2, height: r * 2)
+                context.fill(Path(ellipseIn: rect), with: .color(p.color.opacity(alpha)))
+            }
+
+            // Shockwaves
+            for w in game.shockwaves {
+                let center = CGPoint(x: CGFloat(w.pos.x), y: CGFloat(w.pos.y))
+                let r = CGFloat(w.age) * w.maxRadius
+                let alpha = Double(max(0, 1 - w.age))
+                let rect = CGRect(x: center.x - r, y: center.y - r, width: r * 2, height: r * 2)
+                context.stroke(Path(ellipseIn: rect),
+                               with: .color(.white.opacity(alpha * 0.8)),
+                               lineWidth: max(1, 3 - r * 0.02))
+            }
+
+            // +points toasts
+            for t in game.toasts {
+                let prog = max(0, min(1, t.age / t.lifetime))
+                let rise: CGFloat = 28
+                let pos = CGPoint(x: CGFloat(t.pos.x), y: CGFloat(t.pos.y) - rise * prog)
+
+                // scale pop (ease-out-back-ish)
+                let popPhase = min(prog / 0.25, 1)
+                let scale = 0.9 + (1 - pow(1 - popPhase, 3)) * 0.25
+                let opacity = 1 - Double(prog)
+
+                let label = Text("+\(t.value)")
+                    .font(.system(size: 16, weight: .bold, design: .rounded))
+                    .foregroundStyle(t.color)
+
+                context.opacity = opacity
+
+                // Scale around `pos`
+                context.translateBy(x: pos.x, y: pos.y)
+                context.scaleBy(x: scale, y: scale)
+                context.translateBy(x: -pos.x, y: -pos.y)
+
+                context.draw(label, at: pos, anchor: .center)
+
+                // Reset transform
+                context.translateBy(x: pos.x, y: pos.y)
+                context.scaleBy(x: 1/scale, y: 1/scale)
+                context.translateBy(x: -pos.x, y: -pos.y)
+
+                context.opacity = 1
+            }
+        }
+        .allowsHitTesting(false)
     }
 }


### PR DESCRIPTION
This pull request introduces a new animated "+points" toast effect when enemies are destroyed, and refactors the main game rendering in `OrbiterGameView` by splitting the large canvas into smaller, composable canvas views. This improves both the visual feedback for the player and the maintainability of the rendering code. The most important changes are grouped below:

**New Feature: Animated Kill Toasts**
- Added a `KillToast` struct and a `[KillToast]` array to `GameState` to manage temporary "+points" toasts that appear when enemies are destroyed. Toasts animate upwards and fade out. [[1]](diffhunk://#diff-2c55c70221130a47c38222f5f494841cb2c6c179e5479ac5e54aad65d9ec7f6bR76-R84) [[2]](diffhunk://#diff-eee7c86a3390199db9f4b1a683de48b47cdd739b3453ef450d7e0013e2159f38R20-R21)
- Implemented `emitKillToast` in `GameState` to spawn a toast at the location of a destroyed enemy, showing the points gained in the enemy's color. Toasts are updated and removed as they age. [[1]](diffhunk://#diff-eee7c86a3390199db9f4b1a683de48b47cdd739b3453ef450d7e0013e2159f38R305-R308) [[2]](diffhunk://#diff-eee7c86a3390199db9f4b1a683de48b47cdd739b3453ef450d7e0013e2159f38R453-R456) [[3]](diffhunk://#diff-eee7c86a3390199db9f4b1a683de48b47cdd739b3453ef450d7e0013e2159f38R221-R224)

**Rendering Refactor: Split Canvases**
- Refactored `OrbiterGameView` to break up the monolithic rendering canvas into four smaller SwiftUI views: `PlayfieldCanvas`, `EnemiesCanvas`, `BulletsCanvas`, and `FXCanvas`. Each is responsible for a specific part of the scene, improving code clarity and compile times. [[1]](diffhunk://#diff-ca354abee088ddd8a74c95b81d221fdd4880c84992693d40ba185029c634dd1bR10-R80) [[2]](diffhunk://#diff-ca354abee088ddd8a74c95b81d221fdd4880c84992693d40ba185029c634dd1bR160-R298)
- Integrated the new kill toasts into the `FXCanvas`, where they are animated and drawn above the playfield.

**Minor Improvements & Cleanup**
- Simplified the syntax for phase and pause handling in `OrbiterGameView`, and made minor code cleanups for clarity. [[1]](diffhunk://#diff-ca354abee088ddd8a74c95b81d221fdd4880c84992693d40ba185029c634dd1bL223-R127) [[2]](diffhunk://#diff-ca354abee088ddd8a74c95b81d221fdd4880c84992693d40ba185029c634dd1bR145)

These changes enhance both the user experience and the maintainability of the game's codebase.