### PR TITLE
chore: added debug tools

### DIFF
--- a/Soruces/DisplayLinkAsync.swift
+++ b/Soruces/DisplayLinkAsync.swift
@@ -16,11 +16,8 @@ enum DisplayLinkAsync {
             // Create + configure the CADisplayLink on the main actor.
             Task { @MainActor in
                 let link = CADisplayLink(target: box, selector: #selector(Box.tick(_:)))
-                if #available(iOS 15.0, *) {
-                    link.preferredFrameRateRange = CAFrameRateRange(minimum: 30, maximum: 120, preferred: 0)
-                } else {
-                    link.preferredFramesPerSecond = 0 // automatic
-                }
+                link.preferredFrameRateRange = CAFrameRateRange(minimum: 30, maximum: 120, preferred: 0)
+
                 link.add(to: .main, forMode: .common)
                 box.setLink(link) // now called on the main actor ✅
             }

--- a/Soruces/SettingsView.swift
+++ b/Soruces/SettingsView.swift
@@ -14,6 +14,8 @@ struct SettingsView: View {
     @AppStorage("hapticsEnabled") var hapticsEnabled: Bool = true
     @AppStorage("seenTutorial") private var seenTutorial = false
     @AppStorage("musicEnabled") private var musicEnabled: Bool = true
+    @AppStorage("debugEnabled") private var debugEnabled = false
+    @AppStorage("debugDrawHitboxes") private var debugDrawHitboxes = true
     @State private var confirmReset = false
 
     var body: some View {
@@ -47,6 +49,10 @@ struct SettingsView: View {
                             MusicLoop.shared.stop()
                         }
                     }
+            }
+            Section("Dev Controls") {
+                Toggle("Enable Debug Overlay", isOn: $debugEnabled)
+                Toggle("Show Collision Hitboxes", isOn: $debugDrawHitboxes)
             }
             Section("About") {
                 LabeledContent("Version",


### PR DESCRIPTION
This pull request introduces a dynamic particle budget system to improve performance, as well as new developer-focused debug overlays and controls. The changes automatically adjust visual effects based on frame time, and provide real-time debugging information and hitbox visualization, all of which can be toggled in the settings.

**Performance and Particle System Improvements:**

- Implemented an exponential moving average (EMA) for frame timing in `GameState`, and dynamically scaled the particle budget based on frame performance to maintain smooth gameplay. The number of particles emitted is now automatically adjusted, and a soft cap ensures the particle count never exceeds a set maximum. [[1]](diffhunk://#diff-eee7c86a3390199db9f4b1a683de48b47cdd739b3453ef450d7e0013e2159f38R84-R95) [[2]](diffhunk://#diff-eee7c86a3390199db9f4b1a683de48b47cdd739b3453ef450d7e0013e2159f38L121-R152) [[3]](diffhunk://#diff-eee7c86a3390199db9f4b1a683de48b47cdd739b3453ef450d7e0013e2159f38L437-R468) [[4]](diffhunk://#diff-eee7c86a3390199db9f4b1a683de48b47cdd739b3453ef450d7e0013e2159f38R478-R483)

**Debugging and Developer Tools:**

- Added `DevMeter` and `DebugCanvas` overlays to `OrbiterGameView`, providing real-time FPS, frame time, entity counts, and optional collision hitbox visualization. These overlays are controlled via new toggles in the settings. [[1]](diffhunk://#diff-ca354abee088ddd8a74c95b81d221fdd4880c84992693d40ba185029c634dd1bR21-R23) [[2]](diffhunk://#diff-ca354abee088ddd8a74c95b81d221fdd4880c84992693d40ba185029c634dd1bR35) [[3]](diffhunk://#diff-ca354abee088ddd8a74c95b81d221fdd4880c84992693d40ba185029c634dd1bR59-R70) [[4]](diffhunk://#diff-ca354abee088ddd8a74c95b81d221fdd4880c84992693d40ba185029c634dd1bR315-R375)

**Settings and Configuration:**

- Introduced new "Dev Controls" section in `SettingsView`, allowing users to enable the debug overlay and toggle hitbox rendering. These settings are persisted using `@AppStorage`. [[1]](diffhunk://#diff-f2d95236085e43c43a41ca3bf3a6bb0b328f16516f8cd1327a2c5cee24948338R17-R18) [[2]](diffhunk://#diff-f2d95236085e43c43a41ca3bf3a6bb0b328f16516f8cd1327a2c5cee24948338R53-R56)

**Code Modernization:**

- Simplified the use of `CADisplayLink` by always using `preferredFrameRateRange`, removing legacy code paths for older iOS versions.