### PR TITLE
feat: update enemy spawn rate

### DIFF
--- a/OrbitalDrift.xcodeproj/project.pbxproj
+++ b/OrbitalDrift.xcodeproj/project.pbxproj
@@ -147,19 +147,11 @@
 				3B9D9EAE2E5A30F7006281F0 /* Haptics.swift */,
 				3B9D9EAD2E5A30E9006281F0 /* OverlayViews.swift */,
 				3B9D9EAC2E5A30E1006281F0 /* OrbiterGameView.swift */,
-				3B9D9EFC2E5CDF0E006281F0 /* GameState */,
+				3B9D9EAB2E5A30D8006281F0 /* GameState.swift */,
 				3B9D9EAA2E5A30C2006281F0 /* GameModels.swift */,
 				3B9D9EFA2E5B934D006281F0 /* Vector2.swift */,
 			);
 			path = Soruces;
-			sourceTree = "<group>";
-		};
-		3B9D9EFC2E5CDF0E006281F0 /* GameState */ = {
-			isa = PBXGroup;
-			children = (
-				3B9D9EAB2E5A30D8006281F0 /* GameState.swift */,
-			);
-			path = GameState;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */

--- a/Soruces/GameState.swift
+++ b/Soruces/GameState.swift
@@ -96,13 +96,8 @@ final class GameState {
     
     // MARK: - Timing
     private var lastUpdate: TimeInterval = 0
-    private var spawnAccumulator: TimeInterval = 0
     private var powerupTimer: TimeInterval = 0
     private var scoreAccumulator: TimeInterval = 0
-    
-    // MARK: - Difficulty
-    private var spawnInterval: TimeInterval = 0.9
-    private var minSpawnInterval: TimeInterval = 0.25
     
     // MARK: - Spawn pacing
     private var elapsed: TimeInterval = 0
@@ -156,8 +151,6 @@ final class GameState {
         invulnerability = 0
         score = 0
         
-        spawnInterval = 0.9
-        spawnAccumulator = 0
         powerupTimer = 0
         scoreAccumulator = 0
         scoreMultiplier = 1.0
@@ -310,14 +303,6 @@ final class GameState {
             a.pos.x < -pad || a.pos.x > size.width + pad ||
             a.pos.y < -pad || a.pos.y > size.height + pad ||
             !a.alive
-        }
-        
-        // Spawn logic
-        spawnAccumulator += dt
-        if spawnAccumulator >= spawnInterval {
-            spawnAccumulator = 0
-            spawnAsteroid(size: size)
-            spawnInterval = max(minSpawnInterval, spawnInterval - dt * 0.02)
         }
         
         // Powerup spawns (simple timer/coin-flip)


### PR DESCRIPTION
This pull request refactors and improves the asteroid spawn pacing logic in the `GameState` class, replacing the old fixed-interval spawn approach with a more flexible and scalable system. The new system smoothly ramps up the spawn rate and enemy cap over time, making the gameplay progression more dynamic and tunable.

**Asteroid spawn pacing improvements:**

* Replaced the old `spawnInterval`/`spawnAccumulator` logic with new variables (`elapsed`, `spawnAcc`, etc.) and parameters (`baseSpawnRate`, `rampSpawnBonus`, `rampDuration`, `gracePeriod`) to control spawn rate ramp-up and grace period. [[1]](diffhunk://#diff-eee7c86a3390199db9f4b1a683de48b47cdd739b3453ef450d7e0013e2159f38L99-R113) [[2]](diffhunk://#diff-eee7c86a3390199db9f4b1a683de48b47cdd739b3453ef450d7e0013e2159f38L146-R161)
* Updated the game update loop to calculate the current spawn rate based on elapsed time, ramp up the spawn rate smoothly, and enforce a dynamic cap on concurrent enemies, with a lighter cap during an initial grace period.
* Removed the old spawn logic that used a fixed minimum interval and linear decrease, consolidating all spawn pacing into the new system.

**Dynamic enemy cap:**

* Added a new `maxEnemies(now:)` helper function to determine the maximum number of concurrent enemies based on elapsed time, allowing for a gradual increase in difficulty.