### PR TITLE
feat: updating scoring

### DIFF
--- a/Soruces/OrbiterGameView.swift
+++ b/Soruces/OrbiterGameView.swift
@@ -187,9 +187,8 @@ private struct PlayfieldCanvas: View {
                 height: game.player.radius * 2
             )
             let ringPath = Path(ellipseIn: ringRect)
-            let flash = game.nearMissFlash
-            let ringColor = Color.white.opacity(0.15 + 0.25 * flash)
-            context.stroke(ringPath, with: .color(ringColor), lineWidth: 2 + 1 * flash)
+            let ringColor = Color.white.opacity(0.15 + 0.25)
+            context.stroke(ringPath, with: .color(ringColor), lineWidth: 2 + 1)
             
             // Player
             let playerPos = game.playerPosition()


### PR DESCRIPTION
This pull request refactors the score multiplier system in the `GameState` class to make it more dynamic and rewarding, especially for defeating enemies, while removing the near-miss mechanic. The changes increase the maximum multiplier, slow its decay, and introduce enemy-specific multiplier boosts when asteroids are destroyed. Several variables and visual feedback related to near-misses have also been removed for code simplification.

**Score Multiplier System Updates:**

* Increased `maxMultiplier` from 3.0 to 10.0 and slowed `multiplierDecayPerSec` from 0.25 to 0.08 for a more rewarding and persistent multiplier system.
* Reworked multiplier boost: now, destroying asteroids increases the score multiplier based on the enemy's difficulty, using the new `multiplierBoost(for:)` method. [[1]](diffhunk://#diff-eee7c86a3390199db9f4b1a683de48b47cdd739b3453ef450d7e0013e2159f38L414-R404) [[2]](diffhunk://#diff-eee7c86a3390199db9f4b1a683de48b47cdd739b3453ef450d7e0013e2159f38R590-R597)

**Removal of Near-Miss Mechanic:**

* Removed all code, variables, and visual feedback related to the near-miss mechanic, including `nearMissThreshold`, `lastNearMissAt`, `nearMissFlash`, and associated logic in the update loop and UI. [[1]](diffhunk://#diff-eee7c86a3390199db9f4b1a683de48b47cdd739b3453ef450d7e0013e2159f38L51) [[2]](diffhunk://#diff-eee7c86a3390199db9f4b1a683de48b47cdd739b3453ef450d7e0013e2159f38L115-L118) [[3]](diffhunk://#diff-eee7c86a3390199db9f4b1a683de48b47cdd739b3453ef450d7e0013e2159f38L374-L385) [[4]](diffhunk://#diff-eee7c86a3390199db9f4b1a683de48b47cdd739b3453ef450d7e0013e2159f38L460) [[5]](diffhunk://#diff-ca354abee088ddd8a74c95b81d221fdd4880c84992693d40ba185029c634dd1bL190-R191)

These changes simplify the gameplay mechanics and focus player rewards on enemy destruction rather than risky maneuvers.